### PR TITLE
Fixing the error about variables

### DIFF
--- a/libraries/Form.php
+++ b/libraries/Form.php
@@ -890,7 +890,8 @@ class Form {
 		$config = $this->CI->config->item('form');
 		
 		// check if config file is associative or numeric
-		$is_indexed = (is_numeric(array_shift(array_keys($config)))) ? TRUE : FALSE;
+		$keys= array_keys($config);
+		$is_indexed = (is_numeric(array_shift($keys))) ? TRUE : FALSE;
 		
 		if ($init)	// no key provided
 		{


### PR DESCRIPTION
Fixing the error: 'Only variables should be passed by reference'

> A PHP Error was encountered
Severity: Runtime Notice
Message: Only variables should be passed by reference
Filename: libraries/Form.php
Line Number: 883